### PR TITLE
session save workaround; fixing #7, #15, #17

### DIFF
--- a/src/wrapper
+++ b/src/wrapper
@@ -348,10 +348,8 @@ for arg; do
     fi
 done
 
-if [ "$1" == "winbox" ]; then
-  wine start /unix "$SNAP/usr/libexec/$WINBOX" "$@"
-elif [ "$1" == "winecfg" ]; then
+if [ "$1" == "winecfg" ]; then
   wine winecfg
 else
-  wine start /unix "$SNAP/usr/libexec/$WINBOX" "$@"
+  cp "$SNAP"/usr/libexec/winbox{32,64}.exe "$TMPDIR/" && wine start /unix "$TMPDIR/$WINBOX" "$@"
 fi


### PR DESCRIPTION
In the winbox binary there is probably hardcoded path of tmp files used to save sessions and settings. It's same directory where the executed binary is. This snap is configured to put binaries to R/O directory $SNAPCRAFT_PRIME/usr/libexec/. So tmp files can't be created there.

See attached strace log: [save_session_strace.log](https://github.com/panaceya/winbox/files/10475572/save_session_strace.log)

The workaround is copying the binary to writable $TMPDIR and executing from this location.

It works well for me. Ubuntu 22.04 LTS 