### PR TITLE
Adding support for running winecfg to adjust DPI in Winbox Snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,9 @@ sudo firewall-cmd --reload
 ### Other firewall
 allow UDP 5678
 > NOTE: NOT ALLOW THIS PORT WHEN USING GLOBAL NETWORK ACCESS
+
+Fixing font size/DPI in high resolution displays
+------------------------------------------------
+Run in terminal `winbox.wine winecfg`
+
+The Wine configuration settings window would show up. Now navigate to the Graphics tab. Adjust the dpi slider under the Screen Resolution setting & click OK to apply. Now relauch Winbox to check how it looks.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -90,3 +90,20 @@ apps:
       - wine-7-stable
       - wine-runtime-c20
       - x11
+
+  # The wine command can be used to run applications inside the wine
+  # environment that this snap uses.
+  #
+  # For example, users can configure the wine environment of this snap
+  # by running `myapp.wine winecfg`.
+  wine:
+    extensions: [gnome-3-38]
+    command: bin/sommelier
+    plugs:
+      - opengl
+      - desktop
+      - home
+      - network
+      - wayland
+      - removable-media
+      - x11


### PR DESCRIPTION
This PR adds the ability for users to run `winecfg` via the Snap package by exposing a `wine` app entry (e.g., `winbox.wine winecfg`).

Users can now manually adjust display settings (e.g., DPI scaling) within Wine to improve usability on high-resolution displays like 4K/8K.

This change provides a practical workaround for scaling issues until native DPI support is implemented.

Tested on Kubuntu 22.04.2 LTS with a 4K monitor on x11 & resolution of 3840x2160

@panaceya — tagging you in case this is useful for the Snap packaging.
